### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ accelerate
 safetensors
 omegaconf
 peft
-gradio
+gradio>=4.0.0


### PR DESCRIPTION
version 3 blows up
l the latest PEFT and transformers packages in the future.
  deprecate("fuse_text_encoder_lora", "0.27", LORA_DEPRECATION_MESSAGE)
Traceback (most recent call last):
  File "/media/2TB/PhotoMaker/gradio_demo/app.py", line 285, in <module>
    demo.launch()
  File "/home/oem/miniconda3/envs/torch2/lib/python3.10/site-packages/gradio/blocks.py", line 1996, in launch
    self.validate_queue_settings()
  File "/home/oem/miniconda3/envs/torch2/lib/python3.10/site-packages/gradio/blocks.py", line 1821, in validate_queue_settings
    raise ValueError("Progress tracking requires queuing to be enabled.")
ValueError: Progress tracking requires queuing to be enabled.