### PR TITLE
Bug Fix: Resolve issue with local demo not running

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ gen_images.save('out_photomaker.png')
 ## Start a local gradio demo
 Run the following command:
 
-```python
+```bash
+export PYTHONPATH="/path/to/project:$PYTHONPATH"
 python gradio_demo/app.py
 ```
 

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -282,4 +282,4 @@ with gr.Blocks(css=css) as demo:
     
     gr.Markdown(article)
     
-demo.launch(share=False)
+demo.launch(share=False, server_name="0.0.0.0")

--- a/gradio_demo/app.py
+++ b/gradio_demo/app.py
@@ -282,4 +282,4 @@ with gr.Blocks(css=css) as demo:
     
     gr.Markdown(article)
     
-demo.launch()
+demo.launch(share=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 torch==2.0.1
 torchvision==0.15.2
-pytorch-cuda==11.8
 diffusers==0.25.0
 transformers==4.36.2
 huggingface-hub==0.20.2


### PR DESCRIPTION
This commit addresses the problem encountered when running 'python gradio_demo/app.py', which resulted in the error: 'No module named 'photomaker''. To fix this, an '__init__.py' file has been added to the 'photomaker' directory, marking it as a Python package. Additionally, instructions have been updated to set the 'PYTHONPATH' environment variable appropriately.