### PR TITLE
Allow user to select output image aspect ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Note: only change the base model and add the LoRA modules for better stylization
   <img src="https://cdn-uploads.huggingface.co/production/uploads/6285a9133ab6642179158944/-AC7Hr5YL4yW1zXGe_Izl.jpeg" height=450>
 </p>
 
+### Note about the output aspect ratio
+
+The underlying generative model has billions of parameters. And, whether You believe it or not, **all** of them do affect the output. The width/height (i.e. the "Aspect Ratio") of the output are just a few of these parameters.
+
+For example, using the exact same positive/negative prompts and seed value, only changing the aspect ratio (i.e. the width/height) of the output image, it is possible to generate e.g. following results:
+
+<p align="center">
+  <img src="https://cdn.cleverest.eu/attachment/github.com/TencentARC/PhotoMaker/pull/120/aspect-ratio-matters.png" height=725>
+</p>
+
 # 🔧 Dependencies and Installation
 
 - Python >= 3.8 (Recommend to use [Anaconda](https://www.anaconda.com/download/#linux) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html))

--- a/gradio_demo/aspect_ratio_template.py
+++ b/gradio_demo/aspect_ratio_template.py
@@ -1,0 +1,77 @@
+# Note: Since output width & height need to be divisible by 8, the w & h -values do
+#       not exactly match the stated aspect ratios... but they are "close enough":)
+
+aspect_ratio_list = [
+    {
+        "name": "Instagram (1:1)",
+        "w": 1024,
+        "h": 1024,
+    },
+    {
+        "name": "35mm film / Landscape (3:2)",
+        "w": 1024,
+        "h": 680,
+    },
+    {
+        "name": "35mm film / Portrait (2:3)",
+        "w": 680,
+        "h": 1024,
+    },
+    {
+        "name": "CRT Monitor / Landscape (4:3)",
+        "w": 1024,
+        "h": 768,
+    },
+    {
+        "name": "CRT Monitor / Portrait (3:4)",
+        "w": 768,
+        "h": 1024,
+    },
+    {
+        "name": "Widescreen TV / Landscape (16:9)",
+        "w": 1024,
+        "h": 576,
+    },
+    {
+        "name": "Widescreen TV / Portrait (9:16)",
+        "w": 576,
+        "h": 1024,
+    },
+    {
+        "name": "Widescreen Monitor / Landscape (16:10)",
+        "w": 1024,
+        "h": 640,
+    },
+    {
+        "name": "Widescreen Monitor / Portrait (10:16)",
+        "w": 640,
+        "h": 1024,
+    },
+    {
+        "name": "Cinemascope (2.39:1)",
+        "w": 1024,
+        "h": 424,
+    },
+    {
+        "name": "Widescreen Movie (1.85:1)",
+        "w": 1024,
+        "h": 552,
+    },
+    {
+        "name": "Academy Movie (1.37:1)",
+        "w": 1024,
+        "h": 744,
+    },
+    {
+        "name": "Sheet-print (A-series) / Landscape (297:210)",
+        "w": 1024,
+        "h": 720,
+    },
+    {
+        "name": "Sheet-print (A-series) / Portrait (210:297)",
+        "w": 720,
+        "h": 1024,
+    },
+]
+
+aspect_ratios = {k["name"]: (k["w"], k["h"]) for k in aspect_ratio_list}

--- a/photomaker/pipeline.py
+++ b/photomaker/pipeline.py
@@ -164,7 +164,7 @@ class PhotoMakerStableDiffusionXLPipeline(StableDiffusionXLPipeline):
                 clean_index = 0
                 clean_input_ids = []
                 class_token_index = []
-                # Find out the corrresponding class word token based on the newly added trigger word token
+                # Find out the corresponding class word token based on the newly added trigger word token
                 for i, token_id in enumerate(input_ids):
                     if token_id == image_token_id:
                         class_token_index.append(clean_index - 1)


### PR DESCRIPTION
Create a list of commonly used aspect ratios and allow the user to select one of them; use selected value as width/height of output generator. Old "_Instagram 1:1_" shall remain the default.

**TODO**: Check if the default prompt needs to be modified (including "instagram etc." eats precious tokens)

**Problem**: I am currently unable to test this change locally due to weird error stating "input types 'tensor<foo>' and 'tensor<bar>' are not broadcast compatible" ... before rebasing, I had no issues - now I just can't seem to get rid of this one :-/

**Extra**: fixed a typo in an old comment :D